### PR TITLE
Simplify wmts validation in serializer

### DIFF
--- a/django_geosource/serializers.py
+++ b/django_geosource/serializers.py
@@ -331,14 +331,10 @@ class WMTSSourceSerialize(SourceSerializer):
             .replace("{x}", "1")
         )
         try:
-            r = requests.get(url)
+            requests.get(url)
         except requests.ConnectionError:
             raise ValidationError("Can't reach specified tile server. Check your url.")
 
-        if not r.status_code == 200:
-            raise ValidationError(
-                f"The tile server response is invalid (status code = {r.status_code})."
-            )
         return super().validate(data)
 
 


### PR DESCRIPTION
Instead of making a request & raise validation error if not 200, we let
the user be sure his url is correct, in order to avoid "false validation
error" raised.